### PR TITLE
Various Minor Fixes

### DIFF
--- a/Assets/UI/Panels/NotificationPanel_CQUI.lua
+++ b/Assets/UI/Panels/NotificationPanel_CQUI.lua
@@ -52,14 +52,14 @@ function OnTechBoostActivateNotification( notificationEntry : NotificationType, 
             local techSource = pNotification:GetValue("TechSource");
             if (techIndex ~= nil and techProgress ~= nil and techSource ~= nil) then
                 -- CQUI update all cities real housing when play as India and boosted and researched Sanitation
-                if techIndex == GameInfo.Technologies["TECH_SANITATION"].Index then        -- Sanitation
+                if GameInfo.Technologies["TECH_SANITATION"] and techIndex == GameInfo.Technologies["TECH_SANITATION"].Index then        -- Sanitation
                     if PlayerConfigurations[notificationEntry.m_PlayerID]:GetCivilizationTypeName() == "CIVILIZATION_INDIA" then
                         if Players[notificationEntry.m_PlayerID]:GetTechs():HasTech(techIndex) then
                             LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost(notificationEntry.m_PlayerID);
                         end
                     end
                 -- CQUI update all cities real housing when play as Indonesia and boosted and researched Mass Production
-                elseif techIndex == GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index then        -- Mass Production
+                elseif GameInfo.Technologies["TECH_MASS_PRODUCTION"] and techIndex == GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index then        -- Mass Production
                     if PlayerConfigurations[notificationEntry.m_PlayerID]:GetCivilizationTypeName() == "CIVILIZATION_INDONESIA" then
                         if Players[notificationEntry.m_PlayerID]:GetTechs():HasTech(techIndex) then
                             LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost(notificationEntry.m_PlayerID);
@@ -83,14 +83,14 @@ function OnCivicBoostActivateNotification( notificationEntry : NotificationType,
             local civicSource = pNotification:GetValue("CivicSource");
             if (civicIndex ~= nil and civicProgress ~= nil and civicSource ~= nil) then
                 -- CQUI update all cities real housing when play as Cree and boosted and researched Civil Service
-                if civicIndex == GameInfo.Civics["CIVIC_CIVIL_SERVICE"].Index then -- Civil Service
+                if GameInfo.Civics["CIVIC_CIVIL_SERVICE"] and civicIndex == GameInfo.Civics["CIVIC_CIVIL_SERVICE"].Index then -- Civil Service
                     if PlayerConfigurations[notificationEntry.m_PlayerID]:GetCivilizationTypeName() == "CIVILIZATION_CREE" then
                         if Players[notificationEntry.m_PlayerID]:GetCulture():HasCivic(civicIndex) then
                             LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost(notificationEntry.m_PlayerID);
                         end
                     end
                 -- CQUI update all cities real housing when play as Scotland and boosted and researched Globalization
-                elseif civicIndex == GameInfo.Civics["CIVIC_GLOBALIZATION"].Index then -- Globalization
+                elseif GameInfo.Civics["CIVIC_GLOBALIZATION"] and civicIndex == GameInfo.Civics["CIVIC_GLOBALIZATION"].Index then -- Globalization
                     if PlayerConfigurations[notificationEntry.m_PlayerID]:GetCivilizationTypeName() == "CIVILIZATION_SCOTLAND" then
                         if Players[notificationEntry.m_PlayerID]:GetCulture():HasCivic(civicIndex) then
                             LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost(notificationEntry.m_PlayerID);
@@ -215,9 +215,9 @@ function Initialize_RewardDescriptions()
                 local infoUnit:table = GameInfo.Units[sType];
                 if infoUnit == nil then
                     returnStr = "Warning! Cannot decode"..sSubType;
+                else
+                    returnStr = Locale.Lookup(sDescription, iNum, Locale.Lookup(infoUnit.Name));
                 end
-
-                returnStr = Locale.Lookup(sDescription, iNum, Locale.Lookup(infoUnit.Name));
             elseif g_RewardExceptions[sSubType] == "res" then
                 local iNum:number = tonumber(GetModifierParam(sModifierID, "Amount"));
                 returnStr = Locale.Lookup("LOC_GOODYHUT_STRATEGIC_RESOURCES_DESCRIPTION", iNum);

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -739,7 +739,9 @@ function ViewMain( data:table )
     end
 
     if not GameCapabilities.HasCapability("CAPABILITY_FAITH") then
-        Controls.ProduceWithFaithCheck:SetHide(true);
+        -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
+        -- Controls.ProduceWithFaithCheck:SetHide(true);
+        -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
         Controls.FaithGrid:SetHide(true);
     end
 
@@ -1335,8 +1337,10 @@ function OnProductionPanelClose()
     -- If no longer checked, make sure the side Production Panel closes.
     -- Clear the checks, even if hidden, the Production Pane can close after the City Panel has already been closed.
     Controls.ChangeProductionCheck:SetCheck( false );
-    Controls.ProduceWithFaithCheck:SetCheck( false );
-    Controls.ProduceWithGoldCheck:SetCheck( false );
+    -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
+    -- Controls.ProduceWithFaithCheck:SetCheck( false );
+    -- Controls.ProduceWithGoldCheck:SetCheck( false );
+    -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
 
     AnimateToOpenFromWithProductionQueue();
 end
@@ -1475,32 +1479,34 @@ end
 
 -- ===========================================================================
 function OnTogglePurchaseWithGold()
-    if Controls.ProduceWithGoldCheck:IsChecked() then
-        RecenterCameraOnCity();
-        LuaEvents.CityPanel_PurchaseGoldOpen();
-        -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
-        Controls.ChangeProductionCheck:SetCheck( false );
-        Controls.ProduceWithFaithCheck:SetCheck( false );
-        --AnimateToWithProductionQueue();
-        -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
-    else
-        LuaEvents.CityPanel_ProductionClose();
-    end
+    -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
+    -- CQUI allows purchasing with gold at all times, so no code is required here
+    -- if Controls.ProduceWithGoldCheck:IsChecked() then
+    --     RecenterCameraOnCity();
+    --     LuaEvents.CityPanel_PurchaseGoldOpen();
+    --     Controls.ChangeProductionCheck:SetCheck( false );
+    --     Controls.ProduceWithFaithCheck:SetCheck( false );
+    --     --AnimateToWithProductionQueue();
+    -- else
+    --     LuaEvents.CityPanel_ProductionClose();
+    -- end
+    -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
 end
 
 -- ===========================================================================
 function OnTogglePurchaseWithFaith()
-    if Controls.ProduceWithFaithCheck:IsChecked() then
-        RecenterCameraOnCity();
-        LuaEvents.CityPanel_PurchaseFaithOpen();
-        -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
-        Controls.ChangeProductionCheck:SetCheck( false );
-        Controls.ProduceWithGoldCheck:SetCheck( false );
-        --AnimateToWithProductionQueue();
-        -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
-    else
-        LuaEvents.CityPanel_ProductionClose();
-    end
+    -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
+    -- CQUI allows purchasing with faith at all times, so no code is required here
+    -- if Controls.ProduceWithFaithCheck:IsChecked() then
+    --     RecenterCameraOnCity();
+    --     LuaEvents.CityPanel_PurchaseFaithOpen();
+    --     Controls.ChangeProductionCheck:SetCheck( false );
+    --     Controls.ProduceWithGoldCheck:SetCheck( false );
+    --     --AnimateToWithProductionQueue();
+    -- else
+    --     LuaEvents.CityPanel_ProductionClose();
+    -- end
+    -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
 end
 
 function OnCloseOverviewPanel()

--- a/Assets/UI/Screens/CivicsTree_CQUI.lua
+++ b/Assets/UI/Screens/CivicsTree_CQUI.lua
@@ -129,12 +129,12 @@ function OnCivicComplete( ePlayer:number, eTech:number)
         end
 
         -- CQUI update all cities real housing when play as Cree and researched Civil Service
-        if eTech == GameInfo.Civics["CIVIC_CIVIL_SERVICE"].Index then    -- Civil Service
+        if GameInfo.Civics["CIVIC_CIVIL_SERVICE"] and eTech == GameInfo.Civics["CIVIC_CIVIL_SERVICE"].Index then    -- Civil Service
             if (PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_CREE") then
                 LuaEvents.CQUI_AllCitiesInfoUpdated(ePlayer);
             end
         -- CQUI update all cities real housing when play as Scotland and researched Globalization
-        elseif eTech == GameInfo.Civics["CIVIC_GLOBALIZATION"].Index then    -- Globalization
+        elseif GameInfo.Civics["CIVIC_GLOBALIZATION"] and eTech == GameInfo.Civics["CIVIC_GLOBALIZATION"].Index then    -- Globalization
             if (PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_SCOTLAND") then
                 LuaEvents.CQUI_AllCitiesInfoUpdated(ePlayer);
             end

--- a/Assets/UI/Screens/TechTree_CQUI.lua
+++ b/Assets/UI/Screens/TechTree_CQUI.lua
@@ -130,12 +130,12 @@ function OnResearchComplete( ePlayer:number, eTech:number)
         end
 
         -- CQUI update all cities real housing when play as India and researched Sanitation
-        if eTech == GameInfo.Technologies["TECH_SANITATION"].Index then    -- Sanitation
+        if GameInfo.Technologies["TECH_SANITATION"] and eTech == GameInfo.Technologies["TECH_SANITATION"].Index then    -- Sanitation
             if (PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_INDIA") then
                 LuaEvents.CQUI_AllCitiesInfoUpdated(ePlayer);
             end
         -- CQUI update all cities real housing when play as Indonesia and researched Mass Production
-        elseif eTech == GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index then    -- Mass Production
+        elseif GameInfo.Technologies["TECH_MASS_PRODUCTION"] and eTech == GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index then    -- Mass Production
             if (PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_INDONESIA") then
                 LuaEvents.CQUI_AllCitiesInfoUpdated(ePlayer);
             end

--- a/Assets/UI/WorldView/CityBannerManager_CQUI.lua
+++ b/Assets/UI/WorldView/CityBannerManager_CQUI.lua
@@ -1339,6 +1339,7 @@ function CQUI_OnLensLayerOff( layerNum:number )
     -- print("CityBannerManager_CQUI: CQUI_OnLensLayerOff ENTRY, layerNum:", layerNum);
     if layerNum == m_HexColoringReligion then
         m_isReligionLensActive = false;
+        UILens.ClearLayerHexes(m_HexColoringReligion);
         RealizeReligion();
     end
 

--- a/Assets/UI/WorldViewIconsManager_CQUI.lua
+++ b/Assets/UI/WorldViewIconsManager_CQUI.lua
@@ -8,6 +8,7 @@ include("CQUICommon.lua");
 -- Cached Base Functions
 -- ===========================================================================
 BASE_CQUI_SetResourceIcon = SetResourceIcon;
+BASE_CQUI_AddImprovementRecommendationsForCity = AddImprovementRecommendationsForCity;
 BASE_CQUI_LateInitialize = LateInitialize;
 
 -- ===========================================================================
@@ -18,10 +19,12 @@ local CQUI_RESOURCEICONSTYLE_TRANSPARENT = 1;
 local CQUI_RESOURCEICONSTYLE_HIDDEN = 2;
 
 local CQUI_ResourceIconStyle = CQUI_RESOURCEICONSTYLE_TRANSPARENT;
+local CQUI_ShowImprovementsRecommendations :boolean = false;
 local m_LoadScreenClosed = false;
 
 -- ===========================================================================
 function CQUI_GetSettingsValues()
+    CQUI_ShowImprovementsRecommendations = GameConfiguration.GetValue("CQUI_ShowImprovementsRecommendations") == 1;
     CQUI_ResourceIconStyle = GameConfiguration.GetValue("CQUI_ResourceDimmingStyle");
     if CQUI_ResourceIconStyle == nil then
         print("CQUI_ResourceIconStyle is nil!  Using default value (CQUI_RESOURCEICONSTYLE_TRANSPARENT).");
@@ -91,10 +94,12 @@ end
 
 -- ===========================================================================
 --  CQUI modified AddImprovementRecommendationsForCity functiton
---  Don't show builder recommandation, it's often stupid
+--  Show builder recommendations based on settings
 -- ===========================================================================
 function AddImprovementRecommendationsForCity( pCity:table, pSelectedUnit:table )
-    return;
+    if CQUI_ShowImprovementsRecommendations then
+        BASE_CQUI_AddImprovementRecommendationsForCity( pCity, pSelectedUnit );
+    end
 end
 
 -- ===========================================================================

--- a/Assets/UI/actionpanel.lua
+++ b/Assets/UI/actionpanel.lua
@@ -773,7 +773,8 @@ function OnEndTurnBlockingChanged( ePrevEndTurnBlockingType:number, eNewEndTurnB
 
             -- ==== CQUI CUSTOMIZATION BEGIN  ==================================================================================== --
             -- Azurency : also look at the unit when selecting it.
-            UI.LookAtPlot(unit:GetX(), unit:GetY());
+            pUnit = UI.GetHeadSelectedUnit();
+            UI.LookAtPlot(pUnit:GetX(), pUnit:GetY());
             -- ==== CQUI CUSTOMIZATION BEGIN  ==================================================================================== --
         end
     end

--- a/Assets/UI/unitflagmanager_CQUI.lua
+++ b/Assets/UI/unitflagmanager_CQUI.lua
@@ -178,6 +178,17 @@ function CQUI_OnUnitFlagPointerExited(playerID:number, unitID:number)
         LuaEvents.CQUI_clearUnitPath();
 
         CQUI_IsFlagHover = false;
+        
+        -- If we have a unit selected with queued movement, display that path
+        if (not UI.IsGameCoreBusy()) then
+            local pSelectedUnit :table = UI.GetHeadSelectedUnit();
+            if pSelectedUnit then
+                local endPlotId = UnitManager.GetQueuedDestination( pSelectedUnit );
+                if endPlotId then
+                    LuaEvents.CQUI_showUnitPath(true);
+                end
+            end
+        end
     end
 end
 
@@ -281,7 +292,9 @@ local tReligionPromosMap:table = {
 
 -- add names to speed up TT creation
 for promoType,promoData in pairs(tReligionPromosMap) do
-    promoData.Name = Locale.Lookup( GameInfo.UnitPromotions[ promoType ].Name );
+    if GameInfo.UnitPromotions[ promoType ] then
+        promoData.Name = Locale.Lookup( GameInfo.UnitPromotions[ promoType ].Name );
+    end
 end
 
 -- ===========================================================================

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -342,7 +342,7 @@ function RealizeMovementPath(showQueuedPath:boolean, unitID:number)
 
     -- BEGIN CQUI changes from basegame RealizeMovementPath (1st of 2 in this function)
     CQUI_im = UI.GetInterfaceMode();
-    if (CQUI_im == InterfaceModeTypes.CITY_MANAGEMENT or CQUI_im == InterfaceModeTypes.CITY_RANGE_ATTACK or CQUI_im == InterfaceModeTypes.DISTRICT_RANGE_ATTACK) then
+    if (CQUI_im == InterfaceModeTypes.CITY_MANAGEMENT or CQUI_im == InterfaceModeTypes.CITY_RANGE_ATTACK or CQUI_im == InterfaceModeTypes.DISTRICT_RANGE_ATTACK or CQUI_im == InterfaceModeTypes.RANGE_ATTACK) then
         return;
     end
 
@@ -353,15 +353,17 @@ function RealizeMovementPath(showQueuedPath:boolean, unitID:number)
     else
         kUnit = UI.GetHeadSelectedUnit();
     end
-    -- END CQUI changes from basegame RealizeMovementPath (1 of 2)
 
     -- Bail if no selected unit
     if kUnit == nil then
-        UILens.SetActive("Default");
+        if not CQUI_im == InterfaceModeTypes.VIEW_MODAL_LENS then
+            UILens.SetActive("Default");
+        end
         m_cachedPathUnit = nil;
         m_cachedPathPlotId = -1;
         return;
     end
+    -- END CQUI changes from basegame RealizeMovementPath (1 of 2)
 
     -- Bail if unit is not a type that allows movement.
     if GameInfo.Units[kUnit:GetUnitType()].IgnoreMoves then
@@ -639,7 +641,7 @@ function ClearMovementPath()
     UILens.ClearLayerHexes( g_MovementPath );
     UILens.ClearLayerHexes( g_Numbers );
     -- CQUI : As we show path on over
-    if (UI.GetInterfaceMode() ~= InterfaceModeTypes.CITY_RANGE_ATTACK and UI.GetInterfaceMode() ~= InterfaceModeTypes.DISTRICT_RANGE_ATTACK) then
+    if (UI.GetInterfaceMode() ~= InterfaceModeTypes.CITY_RANGE_ATTACK and UI.GetInterfaceMode() ~= InterfaceModeTypes.DISTRICT_RANGE_ATTACK and UI.GetInterfaceMode() ~= InterfaceModeTypes.RANGE_ATTACK) then
         UILens.ClearLayerHexes( g_AttackRange );
     end
     m_cachedPathUnit = nil;

--- a/Integrations/ML/Lenses/Builder/BuilderLens_Config_Default.lua
+++ b/Integrations/ML/Lenses/Builder/BuilderLens_Config_Default.lua
@@ -118,25 +118,27 @@ if GameInfo.Improvements["IMPROVEMENT_GEOTHERMAL_PLANT"] ~= nil then
 end
 
 
--- SEASIDE RESORTS
+-- SEASIDE RESORTS (Only add if exists)
 --------------------------------------
-table.insert(GetConfigRules("COLOR_BUILDER_LENS_P2"),
-    function(pPlot)
-        PrintPlotCheck(pPlot, "P2 Seaside Resort check");
+if GameInfo.Improvements["IMPROVEMENT_BEACH_RESORT"] ~= nil then
+    table.insert(GetConfigRules("COLOR_BUILDER_LENS_P2"),
+        function(pPlot)
+            PrintPlotCheck(pPlot, "P2 Seaside Resort check");
 
-        local localPlayer = Game.GetLocalPlayer()
-        local pPlayer:table = Players[localPlayer]
-        local resortImprovInfo = GameInfo.Improvements["IMPROVEMENT_BEACH_RESORT"]
-        local iAppeal = pPlot:GetAppeal()
-        if pPlot:GetOwner() == localPlayer and not pPlot:IsMountain() and not plotHasDistrict(pPlot)
-                and iAppeal >= resortImprovInfo.MinimumAppeal
-                and pPlot:GetImprovementType() ~= resortImprovInfo.Index then
+            local localPlayer = Game.GetLocalPlayer()
+            local pPlayer:table = Players[localPlayer]
+            local resortImprovInfo = GameInfo.Improvements["IMPROVEMENT_BEACH_RESORT"]
+            local iAppeal = pPlot:GetAppeal()
+            if pPlot:GetOwner() == localPlayer and not pPlot:IsMountain() and not plotHasDistrict(pPlot)
+                    and iAppeal >= resortImprovInfo.MinimumAppeal
+                    and pPlot:GetImprovementType() ~= resortImprovInfo.Index then
 
-            if plotCanHaveImprovement(pPlayer, pPlot, resortImprovInfo) then
-                return GetConfiguredColor("COLOR_BUILDER_LENS_P2")
+                if plotCanHaveImprovement(pPlayer, pPlot, resortImprovInfo) then
+                    return GetConfiguredColor("COLOR_BUILDER_LENS_P2")
+                end
             end
-        end
-    end)
+        end)
+end
 
 
 -- SKI RESORTS (Only add if exists)


### PR DESCRIPTION
1. Ensure the religion lens is cleared when switching to other lenses, such as the Power lens.

2. Show or hide the builder improvement recommendations based on the CQUI settings.

3. Don't reset the lens back to default when hovering over units if currently on a modal lens.

4. Do not clear the attack arrow on range attacks if hovering over other units.

5. Show unit path on selected unit when not hovering over other unit.

6. Scenario Compatibility: When playing scenarios, some values will be nil due to the different game rules. For instance, some code checks for certain techs or civics that may not exist in scenarios. This adds in checks for these and a few others. Also comments out unnecessary code in the citypanel since the ProduceWithFaithCheck and ProduceWithGoldCheck elements do not exist in the xml.

7. When auto selecting a unit, properly look at the unit when selected