### PR TITLE
City View: Various Fixes

### DIFF
--- a/Assets/Expansion1/Replacements/citypaneloverview_expansion1_CQUI.lua
+++ b/Assets/Expansion1/Replacements/citypaneloverview_expansion1_CQUI.lua
@@ -11,3 +11,9 @@ function ViewPanelAmenities(data:table)
     --kInstance.AmenityYield:SetText( Locale.ToNumber(data.AmenitiesFromGovernors) );
     CQUI_BuildAmenityBubbleInstance("ICON_GOVERNOR_THE_EDUCATOR", data.AmenitiesFromGovernors, "LOC_REPORTS_GOVERNOR");
 end
+
+function RefreshCulturalIdentityPanel()
+    --UILens.SetActive("Loyalty");
+    SetDesiredLens("Loyalty");
+    LuaEvents.CityPanelTabRefresh();
+end

--- a/Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua
+++ b/Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua
@@ -11,3 +11,15 @@ function ViewPanelAmenities(data:table)
     --kInstance.AmenityYield:SetText( Locale.ToNumber(data.AmenitiesFromGovernors) );
     CQUI_BuildAmenityBubbleInstance("ICON_GOVERNOR_THE_EDUCATOR", data.AmenitiesFromGovernors, "LOC_REPORTS_GOVERNOR");
 end
+
+function RefreshCulturalIdentityPanel()
+    --UILens.SetActive("Loyalty");
+    SetDesiredLens("Loyalty");
+    LuaEvents.CityPanelTabRefresh();
+end
+
+function RefreshPowerPanel()
+    --UILens.SetActive("Power");
+    SetDesiredLens("Power");
+    LuaEvents.CityPanelTabRefresh();
+end

--- a/Assets/Expansion2/Replacements/citypanelpower_CQUI.lua
+++ b/Assets/Expansion2/Replacements/citypanelpower_CQUI.lua
@@ -1,0 +1,58 @@
+-- ===========================================================================
+-- Base File
+-- ===========================================================================
+include("CityPanelPower");
+
+-- ===========================================================================
+-- Cached Base Functions
+-- ===========================================================================
+BASE_CQUI_OnRefresh = OnRefresh;
+
+-- ===========================================================================
+-- CQUI Members
+-- ===========================================================================
+local CQUI_ShowCityDetailAdvisor :boolean = false;
+
+function CQUI_OnSettingsUpdate()
+    CQUI_ShowCityDetailAdvisor = GameConfiguration.GetValue("CQUI_ShowCityDetailAdvisor") == 1;
+end
+
+-- ===========================================================================
+--  CQUI modified OnRefresh functiton
+--  Hide advisor if option is disabled
+-- ===========================================================================
+function OnRefresh()
+    if ContextPtr:IsHidden() then
+        return;
+    end
+    
+    local localPlayerID = Game.GetLocalPlayer();
+    local pPlayer = Players[localPlayerID];
+    if (pPlayer == nil) then
+        return;
+    end
+    local pCity = UI.GetHeadSelectedCity();
+    if (pCity == nil) then
+        return;
+    end
+
+    BASE_CQUI_OnRefresh();
+
+  -- Hide the advisor if option is disabled
+  if not Controls.PowerAdvisor:IsHidden() then
+      Controls.PowerAdvisor:SetHide( CQUI_ShowCityDetailAdvisor == false );
+  end
+
+end
+
+-- ===========================================================================
+function Initialize_CityPanelPower_CQUI()
+    LuaEvents.CityPanelTabRefresh.Remove(BASE_CQUI_OnRefresh);
+    Events.CitySelectionChanged.Remove( BASE_CQUI_OnRefresh );
+    LuaEvents.CityPanelTabRefresh.Add(OnRefresh);
+    Events.CitySelectionChanged.Add( OnRefresh );
+
+    LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
+    LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
+end
+Initialize_CityPanelPower_CQUI();

--- a/Assets/UI/Panels/citypaneloverview.lua
+++ b/Assets/UI/Panels/citypaneloverview.lua
@@ -157,7 +157,7 @@ function SetDesiredLens(desiredLens)
             UILens.SetActive(m_desiredLens);
         end
 
-        ContextPtr:SetUpdate(EnsureDesiredLens);
+        --ContextPtr:SetUpdate(EnsureDesiredLens);
     else
         UILens.SetActive(m_desiredLens);
     end
@@ -279,7 +279,7 @@ function HideAll()
     Controls.PanelDynamicTab:SetHide(true);
 
     -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
-    SetDesiredLens("CityManagement");
+    --SetDesiredLens("CityManagement");
     -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
 end
 
@@ -1086,20 +1086,27 @@ end
 function OnCloseButtonClicked()
     -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
     -- CQUI change the behavior of when the Close button is clicked
+    if UI.GetInterfaceMode() == InterfaceModeTypes.BUILDING_PLACEMENT or UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_PLACEMENT then
+        UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
+        LuaEvents.CQUI_CityviewEnable();
+        return;
+    end
+
     LuaEvents.CQUI_CityPanel_CityviewDisable();
     -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
 end
 
 -- ===========================================================================
 function View(data)
-    Controls.OverviewSubheader:SetText(Locale.ToUpper(Locale.Lookup(data.CityName)));
+    local cityName = Locale.Lookup(data.CityName);
+    Controls.OverviewSubheader:SetText(Locale.ToUpper(cityName));
 
     local canChangeName = GameCapabilities.HasCapability("CAPABILITY_RENAME");
     if (canChangeName and not m_kEspionageViewManager:IsEspionageView()) then
         Controls.RenameCityButton:RegisterCallback(Mouse.eLClick, function()
                 Controls.OverviewSubheader:SetHide(true);
 
-                Controls.EditCityName:SetText(Controls.OverviewSubheader:GetText());
+                Controls.EditCityName:SetText(cityName);
                 Controls.EditCityName:SetHide(false);
                 Controls.EditCityName:TakeFocus();
             end);
@@ -1144,6 +1151,7 @@ function Refresh()
     if m_pPlayer ~= nil and m_pCity ~= nil then
         -- Trigger selection callback
         View( m_kData );
+        SetDesiredLens("CityManagement"); -- CQUI - Apply City Management lens
         if m_tabs.selectedControl then
             m_tabs.SelectTab(m_tabs.selectedControl);
         end

--- a/Assets/UI/Panels/productionpanel_CQUI.lua
+++ b/Assets/UI/Panels/productionpanel_CQUI.lua
@@ -576,6 +576,12 @@ end
 --    CQUI modified OnClose via click
 -- ===========================================================================
 function OnClose()
+    if UI.GetInterfaceMode() == InterfaceModeTypes.BUILDING_PLACEMENT or UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_PLACEMENT then
+        UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
+        LuaEvents.CQUI_CityviewEnable();
+        return;
+    end
+
     LuaEvents.CQUI_CityPanel_CityviewDisable();
 end
 

--- a/Assets/UI/WorldView/plotinfo_CQUI.lua
+++ b/Assets/UI/WorldView/plotinfo_CQUI.lua
@@ -56,7 +56,8 @@ function CQUI_UpdateCloseCitiesCitizensWhenCityFounded(playerID, cityID)
 end
 
 -- ===========================================================================
---Takes a table with duplicates and returns a new table without duplicates. Credit to vogomatix at stask exchange for the code
+-- Takes a table with duplicates and returns a new table without duplicates. Credit to vogomatix at stask exchange for the code
+-- ===========================================================================
 function CQUI_RemoveDuplicates(i:table)
     local hash = {};
     local o = {};
@@ -70,8 +71,10 @@ function CQUI_RemoveDuplicates(i:table)
 end
 
 -- ===========================================================================
-function CQUI_DragThresholdExceeded()
-    CQUI_DragThresholdExceeded = true;
+-- Sets the variable tracking if the map was dragged beyond the threshold
+-- ===========================================================================
+function CQUI_SetDragThresholdExceeded( state:boolean )
+    CQUI_DragThresholdExceeded = state;
 end
 
 -- ===========================================================================
@@ -84,6 +87,11 @@ function OnClickCitizen( plotId:number )
         LuaEvents.CQUI_RefreshCitizenManagement(pSelectedCity:GetID());
     end
 
+    if CQUI_DragThresholdExceeded then
+        CQUI_DragThresholdExceeded = false;
+        return false;
+    end
+
     BASE_CQUI_OnClickCitizen(plotId);
 end
 
@@ -92,6 +100,11 @@ end
 --  Update citizens, data and real housing for both cities
 -- ===========================================================================
 function OnClickSwapTile( plotId:number )
+    if CQUI_DragThresholdExceeded then
+        CQUI_DragThresholdExceeded = false;
+        return false;
+    end
+
     local result = BASE_CQUI_OnClickSwapTile(plotId);
 
     local pSelectedCity :table = UI.GetHeadSelectedCity();
@@ -214,7 +227,7 @@ function Initialize_PlotInfo_CQUI()
 
     LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
     LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
-    LuaEvents.CQUI_DragThresholdExceeded.Add(CQUI_DragThresholdExceeded);
+    LuaEvents.CQUI_SetDragThresholdExceeded.Add(CQUI_SetDragThresholdExceeded);
     LuaEvents.CQUI_RefreshPurchasePlots.Add(RefreshPurchasePlots);
 end
 Initialize_PlotInfo_CQUI();

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -68,6 +68,7 @@ end
 -- ===========================================================================
 function StartDragMap()
     CQUI_dragThresholdExceeded = false;
+    LuaEvents.CQUI_SetDragThresholdExceeded(false);
     -- Get the position of the mouse when the Dragging of the map starts
     CQUI_dragStartX, CQUI_dragStartY = UIManager:GetNormalizedMousePos();
 
@@ -78,6 +79,7 @@ end
 function EndDragMap(resetSpin:boolean)
     -- This function is called if nothing handled the release of the mouse button
     CQUI_dragThresholdExceeded = false;
+    LuaEvents.CQUI_SetDragThresholdExceeded(false);
     BASE_CQUI_EndDragMap(resetSpin);
 end
 
@@ -94,7 +96,7 @@ function UpdateDragMap()
               or (math.abs(CQUI_dragStartY - dragStartY) > CQUI_dragThreshold) then
                 CQUI_dragThresholdExceeded = true;
                 -- Fire the event to set the value in PlotInfo
-                LuaEvents.CQUI_DragThresholdExceeded();
+                LuaEvents.CQUI_SetDragThresholdExceeded(true);
             end
         end
     end
@@ -661,6 +663,7 @@ end
 function OnMouseBuildingPlacementCancel( pInputStruct:table )
     -- print_debug("** Function Entry: OnMouseBuildingPlacementCancel (CQUI Hook)");
     if IsCancelAllowed() then
+        UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
         LuaEvents.CQUI_CityviewEnable();
         -- CQUI: Do not call ExitPlacementMode here
         -- ExitPlacementMode( true );
@@ -672,6 +675,7 @@ function OnMouseDistrictPlacementCancel( pInputStruct:table )
     -- print_debug("** Function Entry: OnMouseDistrictPlacementCancel (CQUI Hook)");
     if IsCancelAllowed() then
         LuaEvents.StoreHash(0);
+        UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
         LuaEvents.CQUI_CityviewEnable();
         -- CQUI: Do not call ExitPlacementMode here
         -- ExitPlacementMode( true );

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -605,6 +605,16 @@
             </Items>
         </ImportFiles>
 
+        <ImportFiles id="CQUI_IMPORT_FILES_EXP2_CITYPANELPOWER" criteria="Expansion2">
+            <Properties>
+                <LoadOrder>200</LoadOrder>
+                <Context>InGame</Context>
+            </Properties>
+            <Items>
+                <File>Assets/Expansion2/Replacements/citypanelpower_CQUI.lua</File>
+            </Items>
+        </ImportFiles>
+
         <ImportFiles id="CQUI_IMPORT_FILES_EXP2_CITYSTATES" criteria="Expansion2">
             <Properties>
                 <LoadOrder>200</LoadOrder>
@@ -849,6 +859,14 @@
                 <LoadOrder>200</LoadOrder>
                 <LuaContext>CityPanelOverview</LuaContext>
                 <LuaReplace>Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua</LuaReplace>
+            </Properties>
+        </ReplaceUIScript>
+
+        <ReplaceUIScript id="CQUI_CityPanelPower_EXP2" criteria="Expansion2">
+            <Properties>
+                <LoadOrder>200</LoadOrder>
+                <LuaContext>CityPanelPower</LuaContext>
+                <LuaReplace>Assets/Expansion2/Replacements/citypanelpower_CQUI.lua</LuaReplace>
             </Properties>
         </ReplaceUIScript>
 
@@ -1439,6 +1457,7 @@
         <!-- EXP 2 -->
         <File>Assets/Expansion2/Replacements/CityPanel_Expansion1.lua</File>
         <File>Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua</File>
+        <File>Assets/Expansion2/Replacements/citypanelpower_CQUI.lua</File>
         <File>Assets/Expansion2/Replacements/citystates.xml</File>
         <File>Assets/Expansion2/Replacements/citystates_CQUI_expansion2.lua</File>
         <File>Assets/Expansion2/Replacements/diplomacyactionview_CQUI_expansion2.lua</File>


### PR DESCRIPTION
1. Added support for the Loyalty and Power lenses when selected on their respective tabs.

2. Polished drag threshold code and added it for citizen management and tile swapping.

3. Properly restore City Management view when cancelling district/building placement, whether by right clicking or by clicking the close buttons.

4. Hide the advisor on the Power panel based on the CQUI settings.

5. When changing the name of a city, don't use the all uppercase version of the name in the edit box.